### PR TITLE
exposed aspResourceID as out variable

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,3 @@
-
+output "aspResourceID" {	
+  value = "${azurerm_template_deployment.app_service_plan.outputs["aspResourceID"]}"	
+}


### PR DESCRIPTION
This is required to use shared asp in azurerm_function_app. https://www.terraform.io/docs/providers/azurerm/r/function_app.html#app_service_plan_id
