### PR TITLE
outputs for template deploys has changed to using lookup

### DIFF
--- a/deployASP.json
+++ b/deployASP.json
@@ -62,6 +62,10 @@
     }
   ],
   "outputs": {
+    "aspResourceID": {
+      "value": "[variables('serverFarmId')]",
+      "type": "string"
+    },
     "aseResourceID": {
       "value": "[reference(concat('Microsoft.Web/serverfarms/', variables('aspname')), '2016-09-01', 'Full').properties.hostingEnvironmentId]",
       "type": "string"

--- a/deployASP.json
+++ b/deployASP.json
@@ -62,10 +62,6 @@
     }
   ],
   "outputs": {
-    "aspResourceID": {
-      "value": "[variables('serverFarmId')]",
-      "type": "string"
-    },
     "aseResourceID": {
       "value": "[reference(concat('Microsoft.Web/serverfarms/', variables('aspname')), '2016-09-01', 'Full').properties.hostingEnvironmentId]",
       "type": "string"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,0 @@
-output "aspResourceID" {
-  value = "${lookup(azurerm_template_deployment.app_service_plan.outputs, "aspResourceID")}"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "aspResourceID" {
+  value = "${lookup(azurerm_template_deployment.app_service_plan.outputs, "aspResourceID")}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "aspResourceID" {	
-  value = "${azurerm_template_deployment.app_service_plan.outputs["aspResourceID"]}"	
+output "aspResourceID" {
+  value = "${lookup(azurerm_template_deployment.app_service_plan.outputs, "aspResourceID")}"
 }


### PR DESCRIPTION
- Outputs for template deploys has changed to using lookup. 

- Please  refer 
https://github.com/terraform-providers/terraform-provider-azurerm/issues/578 and https://github.com/terraform-providers/terraform-provider-azurerm/issues/1024#issuecomment-381570431

- Build on sandbox 
worked on saat https://sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_Platform/job/bulk-scan-shared-infrastructure/job/OUTPUT-TEMPLATE-DEPLOYS-USING-LOOKUP/2/console. 
Please note that build failed further for saat as it needs dns changes to be applied but it was able to output using look up.
but still failing sprod https://sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_Platform/job/bulk-scan-shared-infrastructure/job/OUTPUT-TEMPLATE-DEPLOYS-USING-LOOKUP/